### PR TITLE
Specify the workers count for dj

### DIFF
--- a/lib/netguru/capistrano.rb
+++ b/lib/netguru/capistrano.rb
@@ -177,7 +177,8 @@ module Netguru
           end
           #restart DJ
           task :restart_dj do
-            run "cd #{current_path}; #{runner} script/delayed_job restart"
+            set :workers, fetch(:dj_workers, 1)
+            run "cd #{current_path}; #{runner} script/delayed_job restart -n #{workers}"
           end
           #precompile assets
           task :precompile do


### PR DESCRIPTION
Usage

``` ruby
task :production do
   (...)
   set :dj_workers, 3

   after "deploy:update_code", "netguru:restart_dj"
end

task :staging do
  set :dj_workers, 1

  after "deploy:update_code", "netguru:restart_dj"
end
```
